### PR TITLE
Permit to override the list of distro tested

### DIFF
--- a/vars/fedoraInfraTox.groovy
+++ b/vars/fedoraInfraTox.groovy
@@ -1,6 +1,6 @@
 #!groovy
 
-def call(Closure body) {
+def call(Closure body, ArrayList distros = ["f30", "f31", "f32", "latest"]) {
     def stages = [:]
     def fedora_containers = [
                     containerTemplate(name: 'jnlp',
@@ -9,9 +9,8 @@ def call(Closure body) {
                                       args: '${computer.jnlpmac} ${computer.name}',
                                       workingDir: "/workdir")
     ]
-    def active_fedoras = ["f30", "f31", "f32", "latest"]
 
-    active_fedoras.each { fedora ->
+    distros.each { fedora ->
         stages["tox-${fedora}"] = {
             stage("tox-${fedora}"){
                 container("${fedora}"){


### PR DESCRIPTION
Since we might still want to deploy things on EL7 or EL8,
we should make sure the test are run on those distribution.

See https://github.com/fedora-infra/fedbadges/pull/75