### PR TITLE
Invert the order

### DIFF
--- a/vars/fedoraInfraTox.groovy
+++ b/vars/fedoraInfraTox.groovy
@@ -1,6 +1,6 @@
 #!groovy
 
-def call(Closure body, ArrayList distros = ["f30", "f31", "f32", "latest"]) {
+def call(ArrayList distros = ["f30", "f31", "f32", "latest"], Closure body) {
     def stages = [:]
     def fedora_containers = [
                     containerTemplate(name: 'jnlp',


### PR DESCRIPTION
it seems that jenkins add named parameters at the start, and
then add the Closure at the end.

So fedoraInfraTox(["el7"]) { } would not match the existing signature.

Looking at http://docs.groovy-lang.org/latest/html/documentation/#_named_parameters
it seems doable, but would require to fiddle too much with groovy code for me.